### PR TITLE
Refactor spellability

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "dn-m/ArrayTools" "v1.3.6"
+github "dn-m/ArrayTools" "v1.4"
 github "dn-m/EnumTools" "v0.4.2"
 github "dn-m/StringTools" "v0.2.1"
 github "dn-m/ArithmeticTools" "v0.3.14"

--- a/Carthage/Checkouts/ArrayTools/ArrayTools/Predicates.swift
+++ b/Carthage/Checkouts/ArrayTools/ArrayTools/Predicates.swift
@@ -47,12 +47,19 @@ extension SequenceType {
     }
 
     /**
-     - returns: `true` if all `Generator.Element` values in `self` fulfill given `predicate`.
-     Otherwise, `false`.
+     - returns: `true` if all elements satisfy the given `predicate`. Otherwise, `false`.
      */
-    public func allMatch(@noescape predicate: Generator.Element -> Bool) -> Bool {
+    public func allSatisfy(@noescape predicate: Generator.Element -> Bool) -> Bool {
         for element in self { if !predicate(element) { return false } }
         return true
+    }
+    
+    /**
+     - returns: `true` if any elements satisfy the given `predicate`. Otherwise, `false`.
+     */
+    public func anySatisfy(@noescape predicate: Generator.Element -> Bool) -> Bool {
+        for element in self { if predicate(element) { return true } }
+        return false
     }
 }
 

--- a/Carthage/Checkouts/ArrayTools/ArrayToolsTests/PredicatesTests.swift
+++ b/Carthage/Checkouts/ArrayTools/ArrayToolsTests/PredicatesTests.swift
@@ -17,14 +17,23 @@ class PredicatesTests: XCTestCase {
     
     let array = [S(value: 1), S(value: 3), S(value: 2), S(value: 3)]
     
-    func testPredicatesTrue() {
+    func testAllSatisfyTrue() {
         let array = [1,1,1,1,1,1,1,1]
-        XCTAssertTrue(array.allMatch { $0 == 1 })
+        XCTAssertTrue(array.allSatisfy { $0 == 1 })
     }
     
-    func testPredicatesFalse() {
+    func testAllSatisfyFalse() {
         let array = [1,2,3,4,5,6,7,8,9]
-        XCTAssertFalse(array.allMatch { $0 == 1})
+        XCTAssert(array.anySatisfy { $0 == 1})
+    }
+    
+    func testAnySatisfyTrue() {
+        let array = [1,2,3,4,5,6,7,8,9]
+        XCTAssertFalse(array.anySatisfy { $0 == 10})
+    }
+    
+    func testAnySatisfyFalse() {
+        
     }
     
     func testGreatest() {

--- a/PitchSpellingTools.xcodeproj/project.pbxproj
+++ b/PitchSpellingTools.xcodeproj/project.pbxproj
@@ -370,13 +370,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		070156111CF4AAFF00C256E9 /* PitchSpellingGraph */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = PitchSpellingGraph;
-			sourceTree = "<group>";
-		};
 		078175111CD8F70600AAB396 /* PitchSpelling */ = {
 			isa = PBXGroup;
 			children = (
@@ -456,7 +449,6 @@
 			isa = PBXGroup;
 			children = (
 				A3B90C1E0151F49FEB7FC3DF /* Supporting Files */,
-				070156111CF4AAFF00C256E9 /* PitchSpellingGraph */,
 				078175111CD8F70600AAB396 /* PitchSpelling */,
 				07A8C8131CF787F200CFD69B /* PitchSpellingStack.swift */,
 				07A8C8111CF787F200CFD69B /* PitchSpellingEdge.swift */,

--- a/PitchSpellingTools.xcodeproj/project.pbxproj
+++ b/PitchSpellingTools.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		0744DC451CFDE1DA00DDDAD2 /* PitchSubSequenceSpellerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0744DC431CFDE1DA00DDDAD2 /* PitchSubSequenceSpellerTests.swift */; };
 		074B2C091D06279200F937F7 /* PitchSpellingNodeResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074B2C081D06279200F937F7 /* PitchSpellingNodeResourceTests.swift */; };
 		074B2C0A1D06279200F937F7 /* PitchSpellingNodeResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074B2C081D06279200F937F7 /* PitchSpellingNodeResourceTests.swift */; };
+		074CC8971D09953600955A21 /* Spellability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074CC8961D09953600955A21 /* Spellability.swift */; };
+		074CC8981D09953600955A21 /* Spellability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074CC8961D09953600955A21 /* Spellability.swift */; };
 		0752A5481CD69BD0007C25AB /* IntervalQuality.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0752A53D1CD69BD0007C25AB /* IntervalQuality.swift */; };
 		0752A5491CD69BD0007C25AB /* IntervalQuality.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0752A53D1CD69BD0007C25AB /* IntervalQuality.swift */; };
 		0752A54E1CD69BD0007C25AB /* PitchSpeller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0752A5401CD69BD0007C25AB /* PitchSpeller.swift */; };
@@ -215,6 +217,7 @@
 		0744DC401CFDDDB400DDDAD2 /* PitchSubSequenceSpeller.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PitchSubSequenceSpeller.swift; path = PitchSpellingTools/PitchSubSequenceSpeller.swift; sourceTree = "<group>"; };
 		0744DC431CFDE1DA00DDDAD2 /* PitchSubSequenceSpellerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PitchSubSequenceSpellerTests.swift; path = PitchSpellingToolsTests/PitchSubSequenceSpellerTests.swift; sourceTree = "<group>"; };
 		074B2C081D06279200F937F7 /* PitchSpellingNodeResourceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PitchSpellingNodeResourceTests.swift; path = PitchSpellingToolsTests/PitchSpellingNodeResourceTests.swift; sourceTree = "<group>"; };
+		074CC8961D09953600955A21 /* Spellability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Spellability.swift; path = PitchSpellingTools/Spellability.swift; sourceTree = "<group>"; };
 		0752A53D1CD69BD0007C25AB /* IntervalQuality.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = IntervalQuality.swift; path = PitchSpellingTools/IntervalQuality.swift; sourceTree = "<group>"; };
 		0752A5401CD69BD0007C25AB /* PitchSpeller.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PitchSpeller.swift; path = PitchSpellingTools/PitchSpeller.swift; sourceTree = "<group>"; };
 		0752A5411CD69BD0007C25AB /* PitchSpelling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PitchSpelling.swift; path = PitchSpellingTools/PitchSpelling.swift; sourceTree = "<group>"; };
@@ -454,6 +457,7 @@
 				07A8C8111CF787F200CFD69B /* PitchSpellingEdge.swift */,
 				07A8C8141CF787F200CFD69B /* PitchSpellingNode.swift */,
 				0788817C1D00654F00A3ADD4 /* PitchSpellingNodeResource.swift */,
+				074CC8961D09953600955A21 /* Spellability.swift */,
 				0744DC401CFDDDB400DDDAD2 /* PitchSubSequenceSpeller.swift */,
 				0755BD6D1D086DDA004E6AE2 /* PitchSequenceSpeller.swift */,
 				072AD9741D03888500AF9142 /* PitchSequence+PitchSpelling.swift */,
@@ -713,6 +717,7 @@
 				0755BD6E1D086DDA004E6AE2 /* PitchSequenceSpeller.swift in Sources */,
 				078175091CD8F64500AAB396 /* PitchSpelling+Resolution.swift in Sources */,
 				071890EE1CD9614800C5CD17 /* PitchSpelling+CustomStringConvertible.swift in Sources */,
+				074CC8971D09953600955A21 /* Spellability.swift in Sources */,
 				0796E1241CE402B50084667B /* IntervalQualityKind.swift in Sources */,
 				07A8C81D1CF787F200CFD69B /* PitchSpellingNode.swift in Sources */,
 				07A8C80C1CF77A9C00CFD69B /* PitchClass+PitchSpelling.swift in Sources */,
@@ -802,6 +807,7 @@
 				0755BD6F1D086DDA004E6AE2 /* PitchSequenceSpeller.swift in Sources */,
 				0781750A1CD8F64500AAB396 /* PitchSpelling+Resolution.swift in Sources */,
 				071890EF1CD9614800C5CD17 /* PitchSpelling+CustomStringConvertible.swift in Sources */,
+				074CC8981D09953600955A21 /* Spellability.swift in Sources */,
 				0796E1251CE402B50084667B /* IntervalQualityKind.swift in Sources */,
 				07A8C81E1CF787F200CFD69B /* PitchSpellingNode.swift in Sources */,
 				07A8C80D1CF77A9C00CFD69B /* PitchClass+PitchSpelling.swift in Sources */,

--- a/PitchSpellingTools/Dyad+PitchSpelling.swift
+++ b/PitchSpellingTools/Dyad+PitchSpelling.swift
@@ -8,6 +8,7 @@
 
 import Pitch
 
+/// - warning: Incomplement documentation
 extension Dyad {
     
     public enum Error: ErrorType {
@@ -38,14 +39,8 @@ extension Dyad {
     }
     
     public var defaultSpellingDyad: PitchSpellingDyad? {
-        
-        guard let lowerSpelling = lower.defaultSpelling,
-            higherSpelling = higher.defaultSpelling
-        else {
-            return nil
-        }
-        
-        return PitchSpellingDyad(lowerSpelling, higherSpelling)
+        guard let a = lower.defaultSpelling, b = higher.defaultSpelling else { return nil }
+        return PitchSpellingDyad(a,b)
     }
     
     public var objectivelySpellableAndNot: (Pitch, Pitch)? {

--- a/PitchSpellingTools/Dyad+PitchSpelling.swift
+++ b/PitchSpellingTools/Dyad+PitchSpelling.swift
@@ -38,22 +38,6 @@ extension Dyad {
         }
     }
     
-    // REPLACE with Spellability enum
-    public var canBeSpelledObjectively: Bool {
-        return lower.canBeSpelledObjectively && higher.canBeSpelledObjectively
-    }
-    
-    public var isFullyAmbiguouslySpellable: Bool {
-        return !lower.canBeSpelledObjectively && !higher.canBeSpelledObjectively
-    }
-    
-    public var isSemiAmbiguouslySpellable: Bool {
-        return (
-            (lower.canBeSpelledObjectively && !higher.canBeSpelledObjectively) ||
-            (!lower.canBeSpelledObjectively && higher.canBeSpelledObjectively)
-        )
-    }
-    
     public var defaultSpellingDyad: PitchSpellingDyad? {
         
         guard let lowerSpelling = lower.defaultSpelling,
@@ -66,7 +50,7 @@ extension Dyad {
     }
     
     public var objectivelySpellableAndNot: (Pitch, Pitch)? {
-        guard isSemiAmbiguouslySpellable else { return nil }
+        guard spellability == .semiAmbiguous else { return nil }
         return lower.canBeSpelledObjectively && !higher.canBeSpelledObjectively
             ? (lower, higher)
             : (higher, lower)

--- a/PitchSpellingTools/Dyad+PitchSpelling.swift
+++ b/PitchSpellingTools/Dyad+PitchSpelling.swift
@@ -31,10 +31,10 @@ extension Dyad {
     public var spellability: Spellability {
         if lower.canBeSpelledObjectively && higher.canBeSpelledObjectively {
             return .objective
-        } else if isSemiAmbiguouslySpellable {
-            return .semiAmbiguous
-        } else {
+        } else if !lower.canBeSpelledObjectively && !higher.canBeSpelledObjectively {
             return .fullyAmbiguous
+        } else {
+            return .semiAmbiguous
         }
     }
     

--- a/PitchSpellingTools/Dyad+PitchSpelling.swift
+++ b/PitchSpellingTools/Dyad+PitchSpelling.swift
@@ -8,26 +8,24 @@
 
 import Pitch
 
-/// - warning: Incomplement documentation
 extension Dyad {
     
-    public enum Error: ErrorType {
-        case pitchNotFound
-        case cannotSpellPitches
-    }
-    
+    /// - returns: `true` if either `Pitch` value contained herein has a resolution of `0.25`
     public var hasEighthTone: Bool {
         return higher.resolution == 0.25 || lower.resolution == 0.25
     }
     
+    /// - returns: `true` if either `Pitch` value contained herein has a resolution of `0.50`
     public var hasQuarterTone: Bool {
         return higher.resolution == 0.5 || lower.resolution == 0.5
     }
     
+    /// Finest resolution of the `Pitch` values contained herein.
     public var finestResolution: Float {
         return [higher.resolution, lower.resolution].minElement()!
     }
 
+    /// The degree to which a `Dyad` can be spelled.
     public var spellability: Spellability {
         if lower.canBeSpelledObjectively && higher.canBeSpelledObjectively {
             return .objective
@@ -37,40 +35,16 @@ extension Dyad {
             return .semiAmbiguous
         }
     }
-    
-    public var defaultSpellingDyad: PitchSpellingDyad? {
-        guard let a = lower.defaultSpelling, b = higher.defaultSpelling else { return nil }
-        return PitchSpellingDyad(a,b)
-    }
-    
+
+    /** 
+     - returns: A tuple containing the `Pitch` value contained herein that has a `spellability`
+        value of `.objective`, followed by the `Pitch` value contained herein that does not, 
+        if this `Dyad` has a `spellability` value of `.semiObjective`. Otherwise, `nil`.
+    */
     public var objectivelySpellableAndNot: (Pitch, Pitch)? {
         guard spellability == .semiAmbiguous else { return nil }
         return lower.canBeSpelledObjectively && !higher.canBeSpelledObjectively
             ? (lower, higher)
             : (higher, lower)
-    }
-    
-    public func spellWithDefaultSpellings() throws -> SpelledDyad {
-        
-        guard let defaultSpellingDyad = defaultSpellingDyad else {
-            throw Error.cannotSpellPitches
-        }
-        
-        return try spell(with: defaultSpellingDyad)
-    }
-    
-    public func spell(with spellingDyad: PitchSpellingDyad) throws -> SpelledDyad {
-        return SpelledDyad(
-            higher: try spellHigher(with: spellingDyad.a),
-            lower: try spellLower(with: spellingDyad.b)
-        )
-    }
-    
-    internal func spellHigher(with spelling: PitchSpelling) throws -> SpelledPitch {
-        return try higher.spelled(with: spelling)
-    }
-    
-    internal func spellLower(with spelling: PitchSpelling) throws -> SpelledPitch {
-        return try lower.spelled(with: spelling)
     }
 }

--- a/PitchSpellingTools/Dyad+PitchSpelling.swift
+++ b/PitchSpellingTools/Dyad+PitchSpelling.swift
@@ -29,7 +29,7 @@ extension Dyad {
 
     // First stage of refactor
     public var spellability: Spellability {
-        if canBeSpelledObjectively {
+        if lower.canBeSpelledObjectively && higher.canBeSpelledObjectively {
             return .objective
         } else if isSemiAmbiguouslySpellable {
             return .semiAmbiguous

--- a/PitchSpellingTools/Dyad+PitchSpelling.swift
+++ b/PitchSpellingTools/Dyad+PitchSpelling.swift
@@ -27,7 +27,6 @@ extension Dyad {
         return [higher.resolution, lower.resolution].minElement()!
     }
 
-    // First stage of refactor
     public var spellability: Spellability {
         if lower.canBeSpelledObjectively && higher.canBeSpelledObjectively {
             return .objective

--- a/PitchSpellingTools/Dyad+PitchSpelling.swift
+++ b/PitchSpellingTools/Dyad+PitchSpelling.swift
@@ -27,6 +27,18 @@ extension Dyad {
         return [higher.resolution, lower.resolution].minElement()!
     }
 
+    // First stage of refactor
+    public var spellability: Spellability {
+        if canBeSpelledObjectively {
+            return .objective
+        } else if isSemiAmbiguouslySpellable {
+            return .semiAmbiguous
+        } else {
+            return .fullyAmbiguous
+        }
+    }
+    
+    // REPLACE with Spellability enum
     public var canBeSpelledObjectively: Bool {
         return lower.canBeSpelledObjectively && higher.canBeSpelledObjectively
     }

--- a/PitchSpellingTools/Pitch+PitchSpelling.swift
+++ b/PitchSpellingTools/Pitch+PitchSpelling.swift
@@ -26,6 +26,10 @@ extension Pitch {
         }
         return false
     }
+    
+//    public var spellability: Spellability {
+//        if let 
+//    }
  
     /// All `PitchSpelling` structures available for this `Pitch`.
     public var spellings: [PitchSpelling] {

--- a/PitchSpellingTools/Pitch+PitchSpelling.swift
+++ b/PitchSpellingTools/Pitch+PitchSpelling.swift
@@ -21,15 +21,8 @@ extension Pitch {
      ```
      */
     public var canBeSpelledObjectively: Bool {
-        for spelling in spellings {
-            if spelling.coarse == .natural && spelling.fine == .none { return true }
-        }
-        return false
+        return spellings.anySatisfy({ $0.coarse == .natural && $0.fine == .none })
     }
-    
-//    public var spellability: Spellability {
-//        if let 
-//    }
  
     /// All `PitchSpelling` structures available for this `Pitch`.
     public var spellings: [PitchSpelling] {

--- a/PitchSpellingTools/PitchSequenceSpeller.swift
+++ b/PitchSpellingTools/PitchSequenceSpeller.swift
@@ -23,11 +23,12 @@ public final class PitchSequenceSpeller {
         var last: [PitchSet]?
         for set in self.sets {
             var current = last ?? []
-            if set.canBeSpelledObjectively {
+            switch set.spellability {
+            case .objective:
                 current.append(set)
                 result.append(current)
                 last = nil
-            } else {
+            default:
                 current.append(set)
                 last = current
             }

--- a/PitchSpellingTools/PitchSet+PitchSpelling.swift
+++ b/PitchSpellingTools/PitchSet+PitchSpelling.swift
@@ -10,9 +10,10 @@ import Pitch
 
 extension PitchSet {
     
+    // MARK: PitchSpelling
     
+    /// The degree to which a `PitchSet` can be spelled.
     public var spellability: Spellability {
-        
         if isEmpty || self.allSatisfy({ $0.canBeSpelledObjectively }) {
             return .objective
         } else if anySatisfy({ $0.canBeSpelledObjectively }) {
@@ -22,6 +23,13 @@ extension PitchSet {
         }
     }
     
+    /**
+     - throws: `PitchSpelling.Error` if any `Pitch` values herein cannot be spelled with
+     current technology.
+     
+     - returns: `SpelledPitchSet` containing `SpelledPitch` values for each `Pitch` value
+     contained herein.
+     */
     public func spelledWithDefaultSpellings() throws -> SpelledPitchSet {
         return try SpelledPitchSet(self.map { try $0.spelledWithDefaultSpelling() })
     }

--- a/PitchSpellingTools/PitchSet+PitchSpelling.swift
+++ b/PitchSpellingTools/PitchSet+PitchSpelling.swift
@@ -11,9 +11,7 @@ import Pitch
 extension PitchSet {
     
     public var canBeSpelledObjectively: Bool {
-        if isEmpty { return true }
-        for pitch in self { if pitch.canBeSpelledObjectively { return true } }
-        return false
+        return self.allMatch { $0.canBeSpelledObjectively }
     }
     
     public func spelledWithDefaultSpellings() throws -> SpelledPitchSet {

--- a/PitchSpellingTools/PitchSet+PitchSpelling.swift
+++ b/PitchSpellingTools/PitchSet+PitchSpelling.swift
@@ -9,15 +9,17 @@
 import Pitch
 
 extension PitchSet {
-//
-//    public var spellability: Spellability {
-//        if allMatch({ $0.spellability == .objective }) {
-//            
-//        }
-//    }
-//    
-    public var canBeSpelledObjectively: Bool {
-        return self.allSatisfy { $0.canBeSpelledObjectively }
+    
+    
+    public var spellability: Spellability {
+        
+        if isEmpty || self.allSatisfy({ $0.canBeSpelledObjectively }) {
+            return .objective
+        } else if anySatisfy({ $0.canBeSpelledObjectively }) {
+            return .semiAmbiguous
+        } else {
+            return .fullyAmbiguous
+        }
     }
     
     public func spelledWithDefaultSpellings() throws -> SpelledPitchSet {

--- a/PitchSpellingTools/PitchSet+PitchSpelling.swift
+++ b/PitchSpellingTools/PitchSet+PitchSpelling.swift
@@ -9,9 +9,15 @@
 import Pitch
 
 extension PitchSet {
-    
+//
+//    public var spellability: Spellability {
+//        if allMatch({ $0.spellability == .objective }) {
+//            
+//        }
+//    }
+//    
     public var canBeSpelledObjectively: Bool {
-        return self.allMatch { $0.canBeSpelledObjectively }
+        return self.allSatisfy { $0.canBeSpelledObjectively }
     }
     
     public func spelledWithDefaultSpellings() throws -> SpelledPitchSet {

--- a/PitchSpellingTools/PitchSetSpeller.swift
+++ b/PitchSpellingTools/PitchSetSpeller.swift
@@ -50,7 +50,7 @@ public final class PitchSetSpeller: PitchSpeller {
     
     /// If the `PitchSet` herein can be objectively spelled or has only one `Pitch` value.
     private var pitchSetIsObjectivelySpellableOrMonadic: Bool {
-        return pitchSet.allMatch { $0.canBeSpelledObjectively } || pitchSet.isMonadic
+        return pitchSet.allSatisfy { $0.canBeSpelledObjectively } || pitchSet.isMonadic
     }
     
     /// The influence that this `PitchSetSpeller` has when ranking `PitchSpellingNodes`.

--- a/PitchSpellingTools/PitchSpeller.swift
+++ b/PitchSpellingTools/PitchSpeller.swift
@@ -36,8 +36,3 @@ public protocol PitchSpeller {
      */
     func spell() throws -> Result
 }
-
-extension PitchSpeller {
-
-    
-}

--- a/PitchSpellingTools/PitchSpellingRankerFactory.swift
+++ b/PitchSpellingTools/PitchSpellingRankerFactory.swift
@@ -32,23 +32,18 @@ public struct PitchSpellingRankerFactory {
      */
     public func makeRanker(for dyad: Dyad) -> PitchSpellingRanking {
         
-        if dyad.canBeSpelledObjectively {
-
+        switch dyad.spellability {
+        case .objective:
             return DeterminatePitchSpellingRanker(
                 node(forObjectivelySpellablePitch: dyad.lower),
                 node(forObjectivelySpellablePitch: dyad.higher)
             )
-        }
-        
-        if dyad.isFullyAmbiguouslySpellable {
-            
+        case .fullyAmbiguous:
             return FullyAmbiguousPitchSpellingRanker(
                 level(for: dyad.lower),
                 level(for: dyad.higher)
             )
-            
-        } else {
-            
+        case .semiAmbiguous:
             let (objectivelySpellable, subjective) = dyad.objectivelySpellableAndNot!
             return SemiAmbiguousPitchSpellingRanker(
                 objectivelySpellable: node(forObjectivelySpellablePitch: objectivelySpellable),

--- a/PitchSpellingTools/Spellability.swift
+++ b/PitchSpellingTools/Spellability.swift
@@ -1,0 +1,13 @@
+//
+//  Spellability.swift
+//  PitchSpellingTools
+//
+//  Created by James Bean on 6/9/16.
+//
+//
+
+public enum Spellability {
+    case objective
+    case semiAmbiguous
+    case fullyAmbiguous
+}

--- a/PitchSpellingToolsTests/DyadTests.swift
+++ b/PitchSpellingToolsTests/DyadTests.swift
@@ -21,4 +21,19 @@ class DyadTests: XCTestCase {
         let dyad = Dyad(Pitch(noteNumber: 60), Pitch(noteNumber: 60.25))
         XCTAssertEqual(dyad.finestResolution, 0.25)
     }
+    
+    func testSpellabilityObjective() {
+        let dyad = Dyad(60,65)
+        XCTAssert(dyad.spellability == .objective)
+    }
+    
+    func testSpellabilitySemiAmbiguous() {
+        let dyad = Dyad(60,63)
+        XCTAssert(dyad.spellability == .semiAmbiguous)
+    }
+    
+    func testSpellabilityFullyAmbiguous() {
+        let dyad = Dyad(61,63)
+        XCTAssert(dyad.spellability == .fullyAmbiguous)
+    }
 }

--- a/PitchSpellingToolsTests/PitchSet+PitchSpellingTests.swift
+++ b/PitchSpellingToolsTests/PitchSet+PitchSpellingTests.swift
@@ -12,23 +12,28 @@ import Pitch
 
 class PitchSet_PitchSpellingTests: XCTestCase {
 
-    func testCanBeSpelledObjectivelyEmptyTrue() {
+    func testSpellabilityEmptyObjective() {
         let pitchSet: PitchSet = []
-        XCTAssert(pitchSet.canBeSpelledObjectively)
+        XCTAssert(pitchSet.spellability == .objective)
     }
     
-    func testCanBeSpelledObjectivelySingleTrue() {
+    func testSpellabilitySingleObjective() {
         let pitchSet: PitchSet = [69]
-        XCTAssert(pitchSet.canBeSpelledObjectively)
+        XCTAssert(pitchSet.spellability == .objective)
     }
     
-    func testCanBeSpelledObjectivelySingleFalse() {
+    func testSpellabilitySingleFullyAmbiguous() {
         let pitchSet: PitchSet = [70]
-        XCTAssertFalse(pitchSet.canBeSpelledObjectively)
+        XCTAssert(pitchSet.spellability == .fullyAmbiguous)
     }
     
-    func testCanBeSpelledObjectivelyTriadFalse() {
+    func testSpellabilityTriadSemiAmbiguous() {
+        let pitchSet: PitchSet = [63,66,69]
+        XCTAssert(pitchSet.spellability == .semiAmbiguous)
+    }
+    
+    func testSpellabilityTriadFullyAmbiguous() {
         let pitchSet: PitchSet = [63,66,68]
-        XCTAssertFalse(pitchSet.canBeSpelledObjectively)
+        XCTAssert(pitchSet.spellability == .fullyAmbiguous)
     }
 }

--- a/PitchSpellingToolsTests/PitchSet+PitchSpellingTests.swift
+++ b/PitchSpellingToolsTests/PitchSet+PitchSpellingTests.swift
@@ -27,11 +27,6 @@ class PitchSet_PitchSpellingTests: XCTestCase {
         XCTAssertFalse(pitchSet.canBeSpelledObjectively)
     }
     
-    func testCanBeSpelledObjectivelyTriadTrue() {
-        let pitchSet: PitchSet = [70,71,73]
-        XCTAssert(pitchSet.canBeSpelledObjectively)
-    }
-    
     func testCanBeSpelledObjectivelyTriadFalse() {
         let pitchSet: PitchSet = [63,66,68]
         XCTAssertFalse(pitchSet.canBeSpelledObjectively)


### PR DESCRIPTION
Replaces a trio of `bool` values (`.canBeSpelledObjectively`, `isSemiAmbiguouslySpellable`, `isFullyAmbiguouslySpellable`) into a single `enum`, `Spellability`.
